### PR TITLE
troubleshoot error on circleci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,8 +6,10 @@ machine:
 dependencies:
   override:
     - docker info
-    - script/build
+    - docker images
+    - docker ps
 
 test:
   override:
+    - script/build
     - script/test

--- a/script/functions
+++ b/script/functions
@@ -13,5 +13,5 @@ err() {
 }
 
 logger() {
-  docker run --rm --volumes-from rsyslog gliderlabs/alpine:latest logger $@
+  docker run --name logger --volumes-from rsyslog gliderlabs/alpine:latest logger $@
 }

--- a/script/test
+++ b/script/test
@@ -9,21 +9,32 @@ docker images | egrep 'rsyslog\b'
 
 echo
 echo "===> Start a syslog server container."
-docker rm -f rsyslog &> /dev/null || :
+smitty docker rm -f rsyslog || :
 smitty docker run -d -h $(hostname) --name rsyslog -v /tmp/syslogdev:/dev rsyslog
 
 echo
 echo "===> Show rsyslog build options."
-smitty docker run --rm -t rsyslog -v
+smitty docker run -t --name buildopts rsyslog -v
 
 echo
 echo "===> Submit a test log message."
 md5sum=$(date | md5sum | awk '{print $1}')
 type logger
-smitty logger -st jumanjitest $md5sum
+smitty logger -st jumanjitest $md5sum || :
 
 echo
 echo "===> Show server log."
 smitty docker logs rsyslog | tee /tmp/copy-of-logs.out
 echo
 smitty grep $md5sum /tmp/copy-of-logs.out
+
+echo
+echo "===> Remove crufty containers (fails on CircleCI)."
+cids="
+  buildopts
+  logger
+  rsyslog
+"
+for cid in $cids; do
+  docker rm -f $cid &> /dev/null || :
+done


### PR DESCRIPTION
From https://circleci.com/gh/jumanjihouse/docker-rsyslog/2

    FATA[0001] Error response from daemon: Cannot destroy container
    466b834374b3f876d9c98f792730c0d29f4ed508549aca3404db85d7f894ffc9:
    Driver btrfs failed to remove root filesystem
    466b834374b3f876d9c98f792730c0d29f4ed508549aca3404db85d7f894ffc9:
    Failed to destroy btrfs snapshot: operation not permitted
    script/test returned exit code 1