### PR TITLE
simagick/rsyslog 8.1904.0 r1

### DIFF
--- a/ci/build
+++ b/ci/build
@@ -8,7 +8,7 @@ set -o pipefail
 ################################################################################
 
 cat >ci/vars <<EOF
-declare -rx  VERSION="8.1904.0-r0"
+declare -rx  VERSION="8.1904.0-r1"
 declare -rx  BUILD_DATE=$(date +%Y%m%dT%H%M)
 declare -rx  VCS_REF=$(git rev-parse --short HEAD)
 declare -rx  TAG=\${VERSION}-\${BUILD_DATE}-git-\${VCS_REF}

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -2,7 +2,8 @@ FROM alpine:3.10.1
 
 ARG VERSION
 
-RUN apk add --no-cache \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache \
       rsyslog=${VERSION} \
       rsyslog-hiredis \
       rsyslog-snmp \


### PR DESCRIPTION
This pull updates rsyslog to 8.1904.0 r1, and also applies updates to the base package set.